### PR TITLE
Fixed record reader not reporting progress

### DIFF
--- a/src/org/apache/pig/backend/hadoop/executionengine/mapReduceLayer/PigRecordReader.java
+++ b/src/org/apache/pig/backend/hadoop/executionengine/mapReduceLayer/PigRecordReader.java
@@ -209,6 +209,8 @@ public class PigRecordReader extends RecordReader<Text, Tuple> {
             startNanos = System.nanoTime();
         }
         while ((curReader == null) || (curValue = loadfunc.getNext()) == null) {
+            PigStatusReporter.getInstance().progress();
+            
             if (!initNextRecordReader()) {
               return false;
             }


### PR DESCRIPTION
This pull request fixes an issue with loading large amount of small files. Pig wasn't reporting status between file loads, which caused it to fail on timeouts.
