### PR TITLE
PIG-5441 Pig skew join tez grace reducer fails to find shuffle data

### DIFF
--- a/src/org/apache/pig/backend/hadoop/executionengine/tez/runtime/PigGraceShuffleVertexManager.java
+++ b/src/org/apache/pig/backend/hadoop/executionengine/tez/runtime/PigGraceShuffleVertexManager.java
@@ -165,7 +165,8 @@ public class PigGraceShuffleVertexManager extends ShuffleVertexManager {
             Map<String, EdgeProperty> edgeManagers = new HashMap<String, EdgeProperty>();
             for(Map.Entry<String,EdgeProperty> entry : getContext().getInputVertexEdgeProperties().entrySet()) {
                 EdgeProperty edge = entry.getValue();
-                edge = EdgeProperty.create(DataMovementType.SCATTER_GATHER, edge.getDataSourceType(), edge.getSchedulingType(),
+                DataMovementType movementType = edge.getDataMovementType() == DataMovementType.BROADCAST? DataMovementType.BROADCAST: DataMovementType.SCATTER_GATHER;
+                edge = EdgeProperty.create(movementType, edge.getDataSourceType(), edge.getSchedulingType(),
                         edge.getEdgeSource(), edge.getEdgeDestination());
                 edgeManagers.put(entry.getKey(), edge);
             }


### PR DESCRIPTION
PigGraceShuffleVertexManager changes edge to SCATTER_GATHER. for skew join when the right side table has >1 reducers this will cause shuffle error.